### PR TITLE
Fix insertion of user fields into existing MODX user tabs

### DIFF
--- a/assets/components/extrafields/js/mgr/inject/user.js
+++ b/assets/components/extrafields/js/mgr/inject/user.js
@@ -9,8 +9,8 @@ Ext.ComponentMgr.onAvailable('modx-user-tabs', function() {
             let issetField = false;
             field.abs.forEach(abs => {
                 if (issetField) return;
-                let areas = abs.category_id.split('_');
-                if (!Ext.isEmpty(abs.category_id) && areas.length === 1 && tab_index === areas[0]) {
+                let areas = abs.tab_id.replace(/^user_tab_/i, '').split('_');
+                if (Ext.isEmpty(abs.category_id) && areas.length === 1 && tab_index == areas[0]) {
                     if (ExtraFields.utils.checkAbs(abs)) return;
                     field = Object.assign(abs, field);
                     if (tab_index) field.cls = 'main-wrapper';
@@ -28,9 +28,9 @@ Ext.ComponentMgr.onAvailable('modx-user-tabs', function() {
             columns.items.forEach((column, column_index) => {
                 field.abs.forEach(abs => {
                     if (issetField) return;
-                    let areas = abs.category_id.split('_');
+                    let areas = abs.category_id.replace(/^user_tab_/i, '').split('_');
                     if (areas.length === 1) return;
-                    if (tab_index !== areas[0] || column_index !== areas[1]) return;
+                    if (tab_index != areas[0] || (column_index + 1) != areas[1]) return;
                     if (!Ext.isEmpty(abs.category_id)) {
                         if (ExtraFields.utils.checkAbs(abs)) return;
                         field = Object.assign(abs, field);


### PR DESCRIPTION
Currently the insertion of custom user fields into the existing MODX tabs ("General Information", "Settings", etc.) doesn't work.

I far as I can tell, these are the available options:
| MODX Tab | tab_id (efFieldAbs) | category_id (efFieldAbs)
| :-------- | :------- | :------- |
| General Information | user_tab_0 | _empty_
| | user_tab_0 | user_tab_0_1
| | user_tab_0 | user_tab_0_2
| Settings | user_tab_1 | _empty_
| Access Permissions | user_tab_2 | _empty_
| Extended Fields | user_tab_3 | _empty_