### PR TITLE
Fix insertion of resource fields into existing MODX resource tabs

### DIFF
--- a/assets/components/extrafields/js/mgr/inject/resource.js
+++ b/assets/components/extrafields/js/mgr/inject/resource.js
@@ -9,7 +9,7 @@ Ext.ComponentMgr.onAvailable('modx-resource-tabs', function() {
             let issetField = false;
             field.abs.forEach(abs => {
                 if (issetField) return;
-                if (tab.id === abs.category_id) {
+                if ((tab.id === abs.category_id) || (tab.id === abs.tab_id && Ext.isEmpty(abs.category_id))) {
                     if (ExtraFields.utils.checkAbs(abs)) return;
                     field = Object.assign(abs, field);
                     if (tab.id === 'modx-resource-access-permissions') {
@@ -27,7 +27,12 @@ Ext.ComponentMgr.onAvailable('modx-resource-tabs', function() {
             let columns = tab.items[0];
             if (columns.layout !== 'column') return;
 
-            columns.items.forEach(column => {
+            let columnItems = columns.items;
+            // The layout in MODX 3 is different
+            if (tab.id === 'modx-page-settings' && ExtraFields.config.modxversion === '3' && columns.items.length === 2){
+                columnItems = columns.items[0].items.concat(columns.items[1].items);
+            }
+            columnItems.forEach(column => {
                 field.abs.forEach(abs => {
                     if (issetField) return;
                     if (column.id === abs.category_id) {
@@ -43,7 +48,7 @@ Ext.ComponentMgr.onAvailable('modx-resource-tabs', function() {
 
                 if (issetField) return;
 
-                if (column.id === 'modx-page-settings-right') {
+                if ((column.id === 'modx-page-settings-right') && ExtraFields.config.modxversion !== '3') {
                     if (!column.items[3].items) return;
                     let boxes = column.items[3].items[0].items;
                     boxes.forEach(box => {

--- a/core/components/extrafields/lexicon/en/default.inc.php
+++ b/core/components/extrafields/lexicon/en/default.inc.php
@@ -76,6 +76,8 @@ $_lang['modx-page-settings-left'] = 'Settings (modx-page-settings-left)';
 $_lang['modx-page-settings-right'] = 'Settings (modx-page-settings-right)';
 $_lang['modx-page-settings-right-box-left'] = 'Settings (modx-page-settings-right-box-left)';
 $_lang['modx-page-settings-right-box-right'] = 'Settings (modx-page-settings-right-box-right)';
+$_lang['modx-page-settings-box-left'] = 'Settings (modx-page-settings-box-left)';
+$_lang['modx-page-settings-box-right'] = 'Settings (modx-page-settings-box-right)';
 $_lang['modx-resource-access-permissions'] = 'Resource groups';
 
 $_lang['user_tab_0'] = 'General information';

--- a/core/components/extrafields/lexicon/ru/default.inc.php
+++ b/core/components/extrafields/lexicon/ru/default.inc.php
@@ -76,6 +76,8 @@ $_lang['modx-page-settings-left'] = 'Настройки (modx-page-settings-left
 $_lang['modx-page-settings-right'] = 'Настройки (modx-page-settings-right)';
 $_lang['modx-page-settings-right-box-left'] = 'Настройки (modx-page-settings-right-box-left)';
 $_lang['modx-page-settings-right-box-right'] = 'Настройки (modx-page-settings-right-box-right)';
+$_lang['modx-page-settings-box-left'] = 'Настройки (modx-page-settings-box-left)';
+$_lang['modx-page-settings-box-right'] = 'Настройки (modx-page-settings-box-right)';
 $_lang['modx-resource-access-permissions'] = 'Группы ресурсов';
 
 $_lang['user_tab_0'] = 'Общая информация';

--- a/core/components/extrafields/processors/mgr/category/getlist.class.php
+++ b/core/components/extrafields/processors/mgr/category/getlist.class.php
@@ -106,13 +106,22 @@ class efCategoryGetListProcessor extends modObjectGetListProcessor
                     ], $array);
                     break;
                 case 'modx-page-settings':
-                    $array = array_merge([
-                        ['id' => 'modx-page-settings-left', 'name' => $this->modx->lexicon('modx-page-settings-left')],
-                        ['id' => 'modx-page-settings-right', 'name' => $this->modx->lexicon('modx-page-settings-right')],
-                        ['id' => 'modx-page-settings-right-box-left', 'name' => $this->modx->lexicon('modx-page-settings-right-box-left')],
-                        ['id' => 'modx-page-settings-right-box-right', 'name' => $this->modx->lexicon('modx-page-settings-right-box-right')],
-                    ], $array);
-                    break;
+                    if ($this->modx->getVersionData()['version'] === '3') { // In MODX 3 there are different regions available
+                        $array = array_merge([
+                            ['id' => 'modx-page-settings-left', 'name' => $this->modx->lexicon('modx-page-settings-left')],
+                            ['id' => 'modx-page-settings-right', 'name' => $this->modx->lexicon('modx-page-settings-right')],
+                            ['id' => 'modx-page-settings-box-left', 'name' => $this->modx->lexicon('modx-page-settings-box-left')],
+                            ['id' => 'modx-page-settings-box-right', 'name' => $this->modx->lexicon('modx-page-settings-box-right')],
+                        ], $array);
+                    } else {
+                        $array = array_merge([
+                            ['id' => 'modx-page-settings-left', 'name' => $this->modx->lexicon('modx-page-settings-left')],
+                            ['id' => 'modx-page-settings-right', 'name' => $this->modx->lexicon('modx-page-settings-right')],
+                            ['id' => 'modx-page-settings-right-box-left', 'name' => $this->modx->lexicon('modx-page-settings-right-box-left')],
+                            ['id' => 'modx-page-settings-right-box-right', 'name' => $this->modx->lexicon('modx-page-settings-right-box-right')],
+                        ], $array);
+                    }
+                    break;        
                 case 'user_tab_0':
                     $array = array_merge([
                         ['id' => 'user_tab_0_1', 'name' => $this->modx->lexicon('user_tab_0_1')],


### PR DESCRIPTION
Currently the insertion of custom resource fields into the existing MODX tabs doesn't work in all cases:
* Tab "Resource Groups": Doesn't work in MODX 2.x (tested with 2.8.7) and MODX 3 (tested with 3.0.5).
* Tab "Settings": Doesn't work in MODX 3 (tested with 3.0.5) because the layout was changed.