### PR TITLE
Fixed index creation for textfield for MyISAM engine

### DIFF
--- a/core/components/extrafields/src/Processors/HelpProcessor.php
+++ b/core/components/extrafields/src/Processors/HelpProcessor.php
@@ -8,7 +8,7 @@ trait HelpProcessor
     public $fieldmeta = [
         'textfield' => [
             'dbtype' => 'varchar',
-            'precision' => 255,
+            'precision' => 250,
             'phptype' => 'string',
         ],
         'textarea' => [


### PR DESCRIPTION
Не создавались индексы для varchar(255), поэтому поправил текстовые поля на varchar(250)